### PR TITLE
Add polygon selection

### DIFF
--- a/src/components/info/StationMetadata/StationMetadata.css
+++ b/src/components/info/StationMetadata/StationMetadata.css
@@ -1,3 +1,8 @@
 .ReactTable {
     font-size: 0.80em;
+    height: 600px;
+}
+
+.ReactTable .rt-thead {
+    overflow-y: scroll;
 }

--- a/src/components/info/StationMetadata/StationMetadata.js
+++ b/src/components/info/StationMetadata/StationMetadata.js
@@ -96,7 +96,7 @@ export default class StationMetadata extends Component {
       <ReactTable
         data={stations}
         columns={columns}
-        defaultPageSize={10}
+        defaultPageSize={100}
         {...restProps}
       />
     );

--- a/src/components/main/PortalA/PortalA.js
+++ b/src/components/main/PortalA/PortalA.js
@@ -34,6 +34,7 @@ import FrequencySelector from '../../selectors/FrequencySelector/FrequencySelect
 import ObservationCounts from '../../info/ObservationCounts';
 import DateSelector from '../../selectors/DateSelector';
 import { stationFilter } from '../../../utils/portals-common';
+import StationMap from '../../maps/StationMap';
 
 logger.configure({ active: true });
 
@@ -122,6 +123,9 @@ class PortalA extends Component {
       this.state.selectedNetworks,
       this.state.selectedVariables,
       this.state.selectedFrequencies,
+      false, // onlyWithClimatology
+      this.state.allNetworks,
+      this.state.allVariables,
       this.state.allStations
     );
 
@@ -149,20 +153,11 @@ class PortalA extends Component {
     return (
       <Row className="PortalA">
         <Col lg={9} md={8} sm={12} className="Map">
-          <BCBaseMap viewport={BCBaseMap.initialViewport}>
-            <FeatureGroup>
-              <EditControl
-                position={'topleft'}
-              />
-            </FeatureGroup>
-            <LayerGroup>
-              <StationMarkers
-                stations={filteredStations}
-                allNetworks={this.state.allNetworks}
-                allVariables={this.state.allVariables}
-              />
-            </LayerGroup>
-          </BCBaseMap>
+          <StationMap
+            stations={filteredStations}
+            allNetworks={this.state.allNetworks}
+            allVariables={this.state.allVariables}
+          />
         </Col>
 
         <Col lg={3} md={4} sm={12} className="Data">

--- a/src/components/main/PortalA/PortalA.js
+++ b/src/components/main/PortalA/PortalA.js
@@ -102,6 +102,8 @@ class PortalA extends Component {
     this.state.frequencyActions.selectNone();
   };
 
+  handleSetArea = this.handleChange.bind(this, 'area');
+
   componentDidMount() {
     getNetworks().then(response => this.setState({ allNetworks: response.data }));
     getVariables().then(response => this.setState({ allVariables: response.data }));
@@ -124,6 +126,7 @@ class PortalA extends Component {
       this.state.selectedVariables,
       this.state.selectedFrequencies,
       false, // onlyWithClimatology
+      this.state.area,
       this.state.allNetworks,
       this.state.allVariables,
       this.state.allStations
@@ -157,6 +160,7 @@ class PortalA extends Component {
             stations={filteredStations}
             allNetworks={this.state.allNetworks}
             allVariables={this.state.allVariables}
+            onSetArea={this.handleSetArea}
           />
         </Col>
 

--- a/src/components/main/PortalB/PortalB.js
+++ b/src/components/main/PortalB/PortalB.js
@@ -88,6 +88,8 @@ class Portal extends Component {
     this.state.frequencyActions.selectNone();
   };
 
+  handleSetArea = this.handleChange.bind(this, 'area');
+
   componentDidMount() {
     getNetworks().then(response => this.setState({ allNetworks: response.data }));
     getVariables().then(response => this.setState({ allVariables: response.data }));
@@ -110,6 +112,7 @@ class Portal extends Component {
       this.state.selectedVariables,
       this.state.selectedFrequencies,
       false, // onlyWithClimatology
+      this.state.area,
       this.state.allNetworks,
       this.state.allVariables,
       this.state.allStations,
@@ -206,6 +209,7 @@ class Portal extends Component {
               stations={filteredStations}
               allNetworks={this.state.allNetworks}
               allVariables={this.state.allVariables}
+              onSetArea={this.handleSetArea}
             />
           </Col>
           <Col lg={3} md={4} sm={12} className="Data">

--- a/src/components/main/PortalB/PortalB.js
+++ b/src/components/main/PortalB/PortalB.js
@@ -32,6 +32,7 @@ import VariableSelector from '../../selectors/VariableSelector';
 import JSONstringify from '../../util/JSONstringify';
 import FrequencySelector from '../../selectors/FrequencySelector/FrequencySelector';
 import { stationFilter } from '../../../utils/portals-common';
+import StationMap from '../../maps/StationMap';
 
 logger.configure({ active: true });
 
@@ -103,12 +104,15 @@ class Portal extends Component {
 
   render() {
     const filteredStations = this.stationFilter(
-      null,
-      null,
+      null,  // startDate
+      null,  // endDate
       this.state.selectedNetworks,
       this.state.selectedVariables,
       this.state.selectedFrequencies,
-      this.state.allStations
+      false, // onlyWithClimatology
+      this.state.allNetworks,
+      this.state.allVariables,
+      this.state.allStations,
     );
 
     const selections = [
@@ -198,20 +202,11 @@ class Portal extends Component {
 
         <Row>
           <Col lg={9} md={8} sm={12} className="Map">
-            <BCBaseMap viewport={BCBaseMap.initialViewport}>
-              <FeatureGroup>
-                <EditControl
-                  position={'topleft'}
-                />
-              </FeatureGroup>
-              <LayerGroup>
-                <StationMarkers
-                  stations={filteredStations}
-                  allNetworks={this.state.allNetworks}
-                  allVariables={this.state.allVariables}
-                />
-              </LayerGroup>
-            </BCBaseMap>
+            <StationMap
+              stations={filteredStations}
+              allNetworks={this.state.allNetworks}
+              allVariables={this.state.allVariables}
+            />
           </Col>
           <Col lg={3} md={4} sm={12} className="Data">
             <Row>

--- a/src/components/main/PortalC/PortalC.js
+++ b/src/components/main/PortalC/PortalC.js
@@ -94,6 +94,8 @@ class Portal extends Component {
 
     fileFormat: undefined,
     clipToDate: false,
+
+    area: undefined,
   };
 
   handleChange = (name, value) => this.setState({ [name]: value });
@@ -128,6 +130,8 @@ class Portal extends Component {
   toggleClipToDate = this.toggleBoolean.bind(this, 'clipToDate');
   toggleOnlyWithClimatology =
     this.toggleBoolean.bind(this, 'onlyWithClimatology');
+
+  handleSetArea = this.handleChange.bind(this, 'area');
 
   componentDidMount() {
     getNetworks()
@@ -172,6 +176,7 @@ class Portal extends Component {
       this.state.selectedVariables,
       this.state.selectedFrequencies,
       this.state.onlyWithClimatology,
+      this.state.area,
       this.state.allNetworks,
       this.state.allVariables,
       this.state.allStations,
@@ -268,6 +273,7 @@ class Portal extends Component {
               stations={filteredStations}
               allNetworks={this.state.allNetworks}
               allVariables={this.state.allVariables}
+              onSetArea={this.handleSetArea}
             />
           </Col>
 

--- a/src/components/main/PortalC/PortalC.js
+++ b/src/components/main/PortalC/PortalC.js
@@ -40,6 +40,7 @@ import ButtonToolbar from 'react-bootstrap/es/ButtonToolbar';
 import StationMetadata from '../../info/StationMetadata';
 import OnlyWithClimatologyControl
   from '../../controls/OnlyWithClimatologyControl';
+import StationMap from '../../maps/StationMap';
 
 
 logger.configure({ active: true });
@@ -263,20 +264,11 @@ class Portal extends Component {
 
         <Row>
           <Col lg={8} md={6} sm={12} className="Map">
-            <BCBaseMap viewport={BCBaseMap.initialViewport}>
-              <FeatureGroup>
-                <EditControl
-                  position={'topleft'}
-                />
-              </FeatureGroup>
-              <LayerGroup>
-                <StationMarkers
-                  stations={filteredStations}
-                  allNetworks={this.state.allNetworks}
-                  allVariables={this.state.allVariables}
-                />
-              </LayerGroup>
-            </BCBaseMap>
+            <StationMap
+              stations={filteredStations}
+              allNetworks={this.state.allNetworks}
+              allVariables={this.state.allVariables}
+            />
           </Col>
 
           <Col lg={4} md={6} sm={12} className="Data">

--- a/src/components/main/PortalD/PortalD.js
+++ b/src/components/main/PortalD/PortalD.js
@@ -196,11 +196,6 @@ class Portal extends Component {
     return (
       <React.Fragment>
         <Row>
-          <Col>
-            <JSONstringify object={this.state.area}/>
-          </Col>
-        </Row>
-        <Row>
           <Col lg={8} md={6} sm={12} className="Map">
             <StationMap
               stations={filteredStations}

--- a/src/components/main/PortalD/PortalD.js
+++ b/src/components/main/PortalD/PortalD.js
@@ -151,7 +151,7 @@ class Portal extends Component {
     networks: this.state.selectedNetworks,
     variables: this.state.selectedVariables,
     frequencies: this.state.selectedFrequencies,
-    polygon: '',
+    polygon: this.state.area,
     clipToDate: this.state.clipToDate,
     onlyWithClimatology: this.state.onlyWithClimatology,
     dataCategory,

--- a/src/components/main/PortalD/PortalD.js
+++ b/src/components/main/PortalD/PortalD.js
@@ -6,22 +6,12 @@ import memoize from 'memoize-one';
 import flow from 'lodash/fp/flow';
 import map from 'lodash/fp/map';
 import filter from 'lodash/fp/filter';
-import flatten from 'lodash/fp/flatten';
-import get from 'lodash/fp/get';
-import uniq from 'lodash/fp/uniq';
-import intersection from 'lodash/fp/intersection';
-import contains from 'lodash/fp/contains';
-import pick from 'lodash/fp/pick';
 import join from 'lodash/fp/join';
-import tap from 'lodash/fp/tap';
-
-import { BCBaseMap } from 'pcic-react-leaflet-components';
 
 import './PortalD.css';
 
 import logger from '../../../logger';
 import NetworkSelector from '../../selectors/NetworkSelector';
-import StationMarkers from '../../maps/StationMarkers';
 import {
   getNetworks,
   getVariables,
@@ -94,6 +84,8 @@ class Portal extends Component {
 
     fileFormat: undefined,
     clipToDate: false,
+
+    area: undefined,
   };
 
   handleChange = (name, value) => this.setState({ [name]: value });
@@ -128,6 +120,8 @@ class Portal extends Component {
   toggleClipToDate = this.toggleBoolean.bind(this, 'clipToDate');
   toggleOnlyWithClimatology =
     this.toggleBoolean.bind(this, 'onlyWithClimatology');
+
+  handleSetArea = this.handleChange.bind(this, 'area');
 
   componentDidMount() {
     getNetworks()
@@ -172,6 +166,7 @@ class Portal extends Component {
       this.state.selectedVariables,
       this.state.selectedFrequencies,
       this.state.onlyWithClimatology,
+      this.state.area,
       this.state.allNetworks,
       this.state.allVariables,
       this.state.allStations,
@@ -201,11 +196,17 @@ class Portal extends Component {
     return (
       <React.Fragment>
         <Row>
+          <Col>
+            <JSONstringify object={this.state.area}/>
+          </Col>
+        </Row>
+        <Row>
           <Col lg={8} md={6} sm={12} className="Map">
             <StationMap
               stations={filteredStations}
               allNetworks={this.state.allNetworks}
               allVariables={this.state.allVariables}
+              onSetArea={this.handleSetArea}
             />
           </Col>
 

--- a/src/components/main/PortalD/PortalD.js
+++ b/src/components/main/PortalD/PortalD.js
@@ -40,6 +40,7 @@ import ButtonToolbar from 'react-bootstrap/es/ButtonToolbar';
 import StationMetadata from '../../info/StationMetadata';
 import OnlyWithClimatologyControl
   from '../../controls/OnlyWithClimatologyControl';
+import StationMap from '../../maps/StationMap';
 
 
 logger.configure({ active: true });
@@ -201,20 +202,11 @@ class Portal extends Component {
       <React.Fragment>
         <Row>
           <Col lg={8} md={6} sm={12} className="Map">
-            <BCBaseMap viewport={BCBaseMap.initialViewport}>
-              <FeatureGroup>
-                <EditControl
-                  position={'topleft'}
-                />
-              </FeatureGroup>
-              <LayerGroup>
-                <StationMarkers
-                  stations={filteredStations}
-                  allNetworks={this.state.allNetworks}
-                  allVariables={this.state.allVariables}
-                />
-              </LayerGroup>
-            </BCBaseMap>
+            <StationMap
+              stations={filteredStations}
+              allNetworks={this.state.allNetworks}
+              allVariables={this.state.allVariables}
+            />
           </Col>
 
           <Col lg={4} md={6} sm={12} className="Data">

--- a/src/components/maps/LayerControlledFeatureGroup/LayerControlledFeatureGroup.js
+++ b/src/components/maps/LayerControlledFeatureGroup/LayerControlledFeatureGroup.js
@@ -1,0 +1,54 @@
+// React component wrapping Leaflet `FeatureGroup`, with an explicit `layers`
+// prop that controls its layer content.
+//
+// The `layers` prop must contain an array of Leaflet layers (and not of React
+// Leaflet components). Default is an empty array.
+//
+// Note: This component uses the `layers` (first) argument of `L.FeatureGroup`
+// to initialize the layers when created. But the component does not confine
+// itself to just initialization; any change to the component prop `layers`
+// causes the layers content of the feature group to be updated.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { Path, withLeaflet } from 'react-leaflet';
+import { FeatureGroup as LeafletFeatureGroup } from 'leaflet';
+
+
+class LayerControlledFeatureGroup extends Path {
+  static propTypes = {
+    // Array of *Leaflet* layers. Controls content of Feature Group.
+    layers: PropTypes.arrayOf(PropTypes.object),
+    // ... plus a lot more props that are options for the Leaflet FeatureGroup
+  };
+
+  static defaultProps = {
+    layers: [],
+  };
+
+  createLeafletElement(props) {
+    const { layers, ...rest } = props;
+    const options = this.getOptions(rest);
+    const el = new LeafletFeatureGroup(layers, options);
+    this.contextValue = {
+      ...props.leaflet,
+      layerContainer: el,
+      popupContainer: el,
+    };
+    return el;
+  }
+
+  componentDidUpdate() {
+    // TODO: The component breaks if it calls `super.componentDidUpdate()`
+    // However, the model component, React Leaflet `FeatureGroup`, does
+    // in fact call it. Figure out why and fix this.
+    // super.componentDidUpdate();
+    this.leafletElement.clearLayers();
+    for (const layer of this.props.layers) {
+      this.leafletElement.addLayer(layer);
+    }
+  }
+}
+
+export default withLeaflet(LayerControlledFeatureGroup);

--- a/src/components/maps/LayerControlledFeatureGroup/__tests__/smoke.js
+++ b/src/components/maps/LayerControlledFeatureGroup/__tests__/smoke.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Map } from 'react-leaflet';
+import LayerControlledFeatureGroup from '../';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(
+    <Map>
+      <LayerControlledFeatureGroup/>
+    </Map>,
+    div
+  );
+});

--- a/src/components/maps/LayerControlledFeatureGroup/package.json
+++ b/src/components/maps/LayerControlledFeatureGroup/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "LayerControlledFeatureGroup",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./LayerControlledFeatureGroup.js"
+}

--- a/src/components/maps/StationMap/StationMap.js
+++ b/src/components/maps/StationMap/StationMap.js
@@ -64,7 +64,9 @@ export default class StationMap extends Component {
   layersToArea = (layers) => {
     // const area = layersToGeoJSON('GeometryCollection', layers);
     // const area = layersToGeoJSON('FeatureCollection', layers);
-    // TODO: Fix this ...
+    // TODO: Verify assertion below (copied from CE, which has a different be).
+    // TODO: Handle more general geometry?
+    //  See https://github.com/pacificclimate/station-data-portal/pull/18/files#diff-7171e91138869d2b0e1de40b6ea7e584R64-R75
     // The thing that receives this GeoJSON doesn't like `FeatureCollection`s
     // or `GeometryCollection`s.
     // Right now we are therefore only updating with the first Feature, i.e.,

--- a/src/components/maps/StationMap/StationMap.js
+++ b/src/components/maps/StationMap/StationMap.js
@@ -1,14 +1,49 @@
+// This component displays a map with a station marker for each station.
+//
+// Notes on geometry layer group:
+//
+//  Terminology
+//
+//  - Leaflet uses the term 'layer' for all single polygons, markers, etc.
+//    Leaflet uses the term 'layer group' for an object (iteself also a
+//    layer, i.e, a subclass of `Layer`) that groups layers together.
+//
+//  Purpose
+//
+//  - The purpose of the geometry layer group is to allow the user to define
+//    a spatial area of interest. This area drives the spatial data averaging
+//    performed by various other data display tools (graphs, tables).
+//
+//  Behaviour
+//
+//  - The geometry layer group is initially empty. Geometry can be added to
+//    it by any combination of drawing (on the map), uploading (e.g., a
+//    from GeoJSON file), and editing and/or deleting existing geometry.
+//
+//  `onSetArea` callback
+//
+//  - All changes (add, edit) to the contents of the geometry layer group are
+//    communicated by the `DataMap` callback prop `onSetArea`. This callback
+//    is more or less the whole point of the geometry layer group.
+//
+//  - `onSetArea` is called with a single GeoJSON object representing the the
+//    contents of the layer group. But see next point.
+
+
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import without from 'lodash/fp/without';
 
 import { BCBaseMap } from 'pcic-react-leaflet-components';
 import { FeatureGroup, LayerGroup } from 'react-leaflet';
 import { EditControl } from 'react-leaflet-draw';
 import StationMarkers from '../StationMarkers';
+import { geoJSONToLeafletLayers } from '../../../utils/geoJSON-leaflet';
 
 import logger from '../../../logger';
 
 import './StationMap.css';
+import LayerControlledFeatureGroup from '../LayerControlledFeatureGroup';
 
 logger.configure({ active: true });
 
@@ -17,16 +52,97 @@ export default class StationMap extends Component {
     stations: PropTypes.array.isRequired,
     allNetworks: PropTypes.array.isRequired,
     allVariables: PropTypes.array.isRequired,
+    onSetArea: PropTypes.func.isRequired,
   };
 
-  state = {};
+  state = {
+    geometryLayers: [],
+  };
+
+// Handlers for area selection. Converts area to GeoJSON.
+
+  layersToArea = (layers) => {
+    // const area = layersToGeoJSON('GeometryCollection', layers);
+    // const area = layersToGeoJSON('FeatureCollection', layers);
+    // TODO: Fix this ...
+    // The thing that receives this GeoJSON doesn't like `FeatureCollection`s
+    // or `GeometryCollection`s.
+    // Right now we are therefore only updating with the first Feature, i.e.,
+    // first layer. This is undesirable. Best would be to fix the receiver
+    // to handle feature selections; next
+    const layer0 = layers[0];
+    return layer0 && layer0.toGeoJSON();
+  };
+
+  onSetArea = () => {
+    this.props.onSetArea(this.layersToArea(this.state.geometryLayers));
+  };
+
+  layerStyle = (index) => index > 0 ?
+    this.props.inactiveGeometryStyle :
+    this.props.activeGeometryStyle;
+
+  addGeometryLayer = layer => {
+    this.setState(prevState => {
+      layer.setStyle(this.layerStyle(prevState.geometryLayers.length));
+      return { geometryLayers: prevState.geometryLayers.concat([layer]) };
+    }, this.onSetArea);
+  };
+
+  addGeometryLayers = layers => {
+    for (const layer of layers) {
+      this.addGeometryLayer(layer);
+    }
+  };
+
+  editGeometryLayers = layers => {
+    // May not need to do anything to maintain `state.geometryLayers` here.
+    // The contents of the layers are changed, but the layers themselves
+    // (as identities) are not changed in number or identity.
+    // `geometryLayers` is a list of such identities, so doesn't need to change.
+    // Only need to communicate change via onSetArea.
+    // Maybe not; maybe better to create a new copy of geometryLayers. Hmmm.
+    this.onSetArea();
+  };
+
+  deleteGeometryLayers = layers => {
+    this.setState(prevState => {
+      const geometryLayers = without(layers, prevState.geometryLayers);
+      // geometryLayers.forEach((layer, i) => layer.setStyle(this.layerStyle(i)));
+      return { geometryLayers };
+    }, this.onSetArea);
+  };
+
+  eventLayers = e => {
+    // Extract the Leaflet layers from an editing event, returning them
+    // as an array of layers.
+    // Note: `e.layers` is a special class, not an array of layers, so we
+    // have to go through this rigmarole to get the layers.
+    // The alternative of accessing the private property `e.layers._layers`
+    // (a) is naughty, and (b) fails.
+    let layers = [];
+    e.layers.eachLayer(layer => layers.push(layer));
+    return layers;
+  };
+
+  handleAreaCreated = e => this.addGeometryLayer(e.layer);
+  handleAreaEdited = e => this.editGeometryLayers(this.eventLayers(e));
+  handleAreaDeleted = e => this.deleteGeometryLayers(this.eventLayers(e));
+
+  // NOTE: This handler is not used ... yet. But all the infrastructure is
+  // in place for it should it be wanted.
+  handleUploadArea = (geoJSON) => {
+    this.addGeometryLayers(geoJSONToLeafletLayers(geoJSON));
+  };
 
   render() {
     const allowGeometryDraw = true || this.state.geometryLayers.length === 0;
 
     return (
       <BCBaseMap viewport={BCBaseMap.initialViewport}>
-        <FeatureGroup>
+        <LayerControlledFeatureGroup
+          layers={this.state.geometryLayers}
+        >
           <EditControl
             position={'topleft'}
             draw={{
@@ -43,8 +159,11 @@ export default class StationMap extends Component {
                 showLength: false,
               },
             }}
+            onCreated={this.handleAreaCreated}
+            onEdited={this.handleAreaEdited}
+            onDeleted={this.handleAreaDeleted}
           />
-        </FeatureGroup>
+        </LayerControlledFeatureGroup>
         <LayerGroup>
           <StationMarkers
             stations={this.props.stations}
@@ -53,7 +172,6 @@ export default class StationMap extends Component {
           />
         </LayerGroup>
       </BCBaseMap>
-
     );
   }
 }

--- a/src/components/maps/StationMap/StationMap.js
+++ b/src/components/maps/StationMap/StationMap.js
@@ -1,0 +1,60 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+
+import { BCBaseMap } from 'pcic-react-leaflet-components';
+import { FeatureGroup, LayerGroup } from 'react-leaflet';
+import { EditControl } from 'react-leaflet-draw';
+import StationMarkers from '../StationMarkers';
+
+import logger from '../../../logger';
+
+import './StationMap.css';
+
+logger.configure({ active: true });
+
+export default class StationMap extends Component {
+  static propTypes = {
+    stations: PropTypes.array.isRequired,
+    allNetworks: PropTypes.array.isRequired,
+    allVariables: PropTypes.array.isRequired,
+  };
+
+  state = {};
+
+  render() {
+    const allowGeometryDraw = true || this.state.geometryLayers.length === 0;
+
+    return (
+      <BCBaseMap viewport={BCBaseMap.initialViewport}>
+        <FeatureGroup>
+          <EditControl
+            position={'topleft'}
+            draw={{
+              marker: false,
+              circlemarker: false,
+              circle: false,
+              polyline: false,
+              polygon: allowGeometryDraw && {
+                showArea: false,
+                showLength: false,
+              },
+              rectangle: allowGeometryDraw && {
+                showArea: false,
+                showLength: false,
+              },
+            }}
+          />
+        </FeatureGroup>
+        <LayerGroup>
+          <StationMarkers
+            stations={this.props.stations}
+            allNetworks={this.props.allNetworks}
+            allVariables={this.props.allVariables}
+          />
+        </LayerGroup>
+      </BCBaseMap>
+
+    );
+  }
+}
+

--- a/src/components/maps/StationMap/__tests__/smoke.js
+++ b/src/components/maps/StationMap/__tests__/smoke.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import StationMap from '../StationMap';
+
+it('renders without crashing', () => {
+    const div = document.createElement('div');
+    ReactDOM.render(<StationMap/>, div);
+});
+

--- a/src/components/maps/StationMap/package.json
+++ b/src/components/maps/StationMap/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "StationMap",
+  "version": "0.0.0",
+  "private": true,
+  "main": "StationMap.js"
+}

--- a/src/data-services/pdp-data-service.js
+++ b/src/data-services/pdp-data-service.js
@@ -9,6 +9,7 @@ import map from 'lodash/fp/map';
 import padCharsStart from 'lodash/fp/padCharsStart';
 import tap from 'lodash/fp/tap';
 import uniq from 'lodash/fp/uniq';
+import { geoJSON2WKT } from '../utils/geographic-encodings';
 
 
 const pad2 = padCharsStart('0', 2);
@@ -71,7 +72,7 @@ export const dataDownloadTarget =
         'network-name': networkSelectorOptions2pdpFormat(networks),
         'input-vars': variableSelectorOptions2pdpFormat(variables),
         'input-freq': frequencyOptions2pdpFormat(frequencies),
-        'input-polygon': polygon || '',
+        'input-polygon': geoJSON2WKT(polygon),
         'only-with-climatology': onlyWithClimatology ? 'only-with-climatology' : '',
         [`download-${dataCategory}`]: capitalize(dataCategory),
         'data-format': get('value')(dataFormat),

--- a/src/utils/geoJSON-leaflet.js
+++ b/src/utils/geoJSON-leaflet.js
@@ -1,0 +1,88 @@
+import { GeoJSON } from 'leaflet';
+
+export function geoJSONToLeafletLayers(geoJSON) {
+  // Returns an *array* of Leaflet `Layer`s
+  // that represent the GeoJSON object passed in.
+  //
+  // Leaflet's function `GeoJSON.geometryToLayer`, which is at the core of
+  // this function, has the following shortcomings:
+  //
+  //  (a) handles only GeoJSON `Feature`s, and not `FeatureCollection`s, and
+  //  (b) errors out with `GeometryCollection`s
+  //  (c) may return a Leaflet FeatureGroup in the case of GeoJSON `MultiPoint`s
+  //
+  // We handle (a) by returning an array of layers, one for each Feature in a
+  // FeatureCollection, and an array of one item for a single Feature.
+  //
+  // We handle (b) similarly to (a).
+  //
+  // We handle (c) by ignoring it for the moment, since it is unlikely to arise
+  // and in any case ought to be handled OK by Leaflet (since `FeatureGroup` is
+  // a subclass of `Layer`).
+
+  const geoJSONType = geoJSON && geoJSON.type;
+  switch (geoJSONType) {
+    case undefined:
+      // This isn't strictly valid GeoJSON, but there's no need to be
+      // *prissy* about it.
+      return [];
+    case 'Feature':
+      if (geoJSON.geometry.type === 'GeometryCollection') {
+        return geoJSON.geometry.geometries.map(GeoJSON.geometryToLayer);
+      }
+      return [GeoJSON.geometryToLayer(geoJSON)];
+    case 'FeatureCollection':
+      return geoJSON.features.map(GeoJSON.geometryToLayer);
+    default:
+      throw new Error(`Invalid GeoJSON object type '${geoJSONType}'`);
+  }
+}
+
+const geoJSONProperties = { source: 'PCIC Climate Explorer' };
+
+export function layersToGeoJSON(collectionType, layers) {
+  // Convert an array of Leaflet layers to GeoJSON according to
+  // argument `collectionType`:
+  //
+  //  - `'FeatureCollection'`: a GeoJSON FeatureCollection.
+  //    Each layer becomes a Feature.
+  //
+  //  - `'GeometryCollection'`: a single GeoJSON Feature with
+  //    geometry that is a GeometryCollection containing all the
+  //    Leaflet layers.
+  //
+  // In the case of an empty array, return `{}`.
+  //
+  // In the case of an array with 1 element, return a single GeoJSON Feature.
+
+  if (layers.length === 0) {
+    return {};
+  }
+
+  if (layers.length === 1) {
+    const geoJSON = layers[0].toGeoJSON();
+    geoJSON.properties = geoJSONProperties;
+    return geoJSON;
+  }
+
+  if (collectionType === 'FeatureCollection') {
+    return {
+      type: 'FeatureCollection',
+      properties: geoJSONProperties,
+      features: layers.map(layer => layer.toGeoJSON()),
+    };
+  }
+
+  if (collectionType === 'GeometryCollection') {
+    return {
+      type: 'Feature',
+      properties: geoJSONProperties,
+      geometry: {
+        type: 'GeometryCollection',
+        geometries: layers.map(layer => layer.toGeoJSON().geometry),
+      },
+    };
+  }
+
+  throw new Error(`Invalid GeoJSON collection type: '${collectionType}'`);
+}

--- a/src/utils/geographic-encodings.js
+++ b/src/utils/geographic-encodings.js
@@ -1,0 +1,47 @@
+// Convert a GeoJSON object into a WKT string.
+// Adapted from (ahem) somewhat problematic Climate Explorer code.
+// Caveat emptor.
+export const geoJSON2WKT = gj => {
+  if (!(gj && gj.type)) {
+    return '';
+  }
+
+  function pairWKT (c) {
+    return c.join(' ');
+  }
+
+  function ringWKT (r) {
+    return r.map(pairWKT).join(', ');
+  }
+
+  function ringsWKT (r) {
+    return r.map(ringWKT).map(wrapParens).join(', ');
+  }
+
+  function multiRingsWKT (r) {
+    return r.map(ringsWKT).map(wrapParens).join(', ');
+  }
+
+  function wrapParens (s) { return '(' + s + ')'; }
+
+  switch (gj.type) {
+    case 'Feature':
+      return geoJSON2WKT(gj.geometry);
+    case 'Point':
+      return 'POINT (' + pairWKT(gj.coordinates) + ')';
+    case 'LineString':
+      return 'LINESTRING (' + ringWKT(gj.coordinates) + ')';
+    case 'Polygon':
+      return 'POLYGON (' + ringsWKT(gj.coordinates) + ')';
+    case 'MultiPoint':
+      return 'MULTIPOINT (' + ringWKT(gj.coordinates) + ')';
+    case 'MultiPolygon':
+      return 'MULTIPOLYGON (' + multiRingsWKT(gj.coordinates) + ')';
+    case 'MultiLineString':
+      return 'MULTILINESTRING (' + ringsWKT(gj.coordinates) + ')';
+    case 'GeometryCollection':
+      return 'GEOMETRYCOLLECTION (' + gj.geometries.map(geoJSON2WKT).join(', ') + ')';
+    default:
+      throw new Error('geoJSON2WKT requires a valid GeoJSON Feature or geometry object as input');
+  }
+};

--- a/src/utils/geometry-algorithms/__tests__/geometry-algorithms.js
+++ b/src/utils/geometry-algorithms/__tests__/geometry-algorithms.js
@@ -1,7 +1,7 @@
 import each from 'jest-each';
 import {
   isLeft, isPointInPolygonWn
-} from '../geospatial';
+} from '../geometry-algorithms';
 
 
 // Helpers

--- a/src/utils/geometry-algorithms/geometry-algorithms.js
+++ b/src/utils/geometry-algorithms/geometry-algorithms.js
@@ -1,4 +1,4 @@
-// Geospatial tools
+// Geometry algorithms
 //
 // Adapted from http://geomalgorithms.com/
 // Copyright 2000 softSurfer, 2012 Dan Sunday

--- a/src/utils/geometry-algorithms/package.json
+++ b/src/utils/geometry-algorithms/package.json
@@ -2,5 +2,5 @@
   "name": "geospatial",
   "version": "0.0.0",
   "private": true,
-  "main": "./geospatial.js"
+  "main": "geometry-algorithms.js"
 }

--- a/src/utils/portals-common/portals-common.js
+++ b/src/utils/portals-common/portals-common.js
@@ -107,6 +107,8 @@ export const stationFilter = (
       if (!area) {
         return true;
       }
+      // TODO: Handle more generalized geometry?
+      //  See https://github.com/pacificclimate/station-data-portal/issues/21
       checkGeoJSONPolygon(area.geometry);
       // Dumbest possible version: Only test the first vertex list in the
       // polygon.

--- a/src/utils/portals-common/portals-common.js
+++ b/src/utils/portals-common/portals-common.js
@@ -7,7 +7,7 @@ import intersection from 'lodash/fp/intersection';
 import map from 'lodash/fp/map';
 import some from 'lodash/fp/some';
 import uniq from 'lodash/fp/uniq';
-import { isPointInPolygonWn } from '../geospatial';
+import { isPointInPolygonWn } from '../geometry-algorithms';
 
 
 const checkGeoJSONPolygon = geometry => {

--- a/src/utils/portals-common/portals-common.js
+++ b/src/utils/portals-common/portals-common.js
@@ -1,4 +1,5 @@
 import contains from 'lodash/fp/contains';
+import every from 'lodash/fp/every';
 import filter from 'lodash/fp/filter';
 import flatten from 'lodash/fp/flatten';
 import flow from 'lodash/fp/flow';
@@ -6,11 +7,23 @@ import intersection from 'lodash/fp/intersection';
 import map from 'lodash/fp/map';
 import some from 'lodash/fp/some';
 import uniq from 'lodash/fp/uniq';
+import { isPointInPolygonWn } from '../geospatial';
+
+
+const checkGeoJSONPolygon = geometry => {
+  if (geometry['type'] !== 'Polygon') {
+    throw new Error(`Invalid geometry type: ${geometry['type']}`)
+  }
+};
+
+const getX = point => point[0];
+const getY = point => point[1];
+export const isPointInGeoJSONPolygon = isPointInPolygonWn(getX, getY);
 
 
 export const stationFilter = (
   startDate, endDate, selectedNetworks, selectedVariables, selectedFrequencies,
-  onlyWithClimatology, allNetworks, allVariables, allStations
+  onlyWithClimatology, area, allNetworks, allVariables, allStations
 ) => {
   // console.log('filteredStations allStations', allStations)
   // console.log('filteredStations allVariables', this.state.allVariables)
@@ -74,7 +87,7 @@ export const stationFilter = (
       )
     }),
 
-    // Station matches `onlyWithClimatology`:
+    // Stations match `onlyWithClimatology`:
     // If `onlyWithClimatology`, station reports a climatology variable.
     filter(station => {
       if (!onlyWithClimatology) {
@@ -87,6 +100,19 @@ export const stationFilter = (
         // PDP PCDS backend
         some(({ cell_method }) => /(within|over)/.test(cell_method))
       )(allVariables)
+    }),
+
+    // Stations are inside `area`
+    filter(station => {
+      if (!area) {
+        return true;
+      }
+      checkGeoJSONPolygon(area.geometry);
+      // Dumbest possible version: Only test the first vertex list in the
+      // polygon.
+      return isPointInGeoJSONPolygon(
+        area.geometry.coordinates[0],
+        [station.histories[0].lon, station.histories[0].lat])
     }),
   )(allStations);
 };


### PR DESCRIPTION
Resolves #10 

We already had the polygon controls on the map. Need to copy (naughty, but fast) over polygon handling from Climate Explorer and integrate it into SDP.

To do:

- [x] Add polygon handling to map: set `state.area`.
- [x] Add polygon station filtering: use `state.area`.
- [x] Add polygon to target of Download Timeseries/Climatology: use `state.area`.