### PR TITLE
Multipolygons

### DIFF
--- a/src/components/maps/StationMap/StationMap.js
+++ b/src/components/maps/StationMap/StationMap.js
@@ -38,7 +38,7 @@ import { BCBaseMap } from 'pcic-react-leaflet-components';
 import { FeatureGroup, LayerGroup } from 'react-leaflet';
 import { EditControl } from 'react-leaflet-draw';
 import StationMarkers from '../StationMarkers';
-import { geoJSONToLeafletLayers } from '../../../utils/geoJSON-leaflet';
+import { geoJSONToLeafletLayers, layersToGeoJSONMultipolygon } from '../../../utils/geoJSON-leaflet';
 
 import logger from '../../../logger';
 
@@ -70,18 +70,8 @@ export default class StationMap extends Component {
 // Handlers for area selection. Converts area to GeoJSON.
 
   layersToArea = (layers) => {
-    // const area = layersToGeoJSON('GeometryCollection', layers);
-    // const area = layersToGeoJSON('FeatureCollection', layers);
-    // TODO: Verify assertion below (copied from CE, which has a different be).
-    // TODO: Handle more general geometry?
-    //  See https://github.com/pacificclimate/station-data-portal/pull/18/files#diff-7171e91138869d2b0e1de40b6ea7e584R64-R75
-    // The thing that receives this GeoJSON doesn't like `FeatureCollection`s
-    // or `GeometryCollection`s.
-    // Right now we are therefore only updating with the first Feature, i.e.,
-    // first layer. This is undesirable. Best would be to fix the receiver
-    // to handle feature selections; next
-    const layer0 = layers[0];
-    return layer0 && layer0.toGeoJSON();
+    //convert one or more geometry layer to a geoJSON Multipolygon
+    return layers && layersToGeoJSONMultipolygon(layers);
   };
 
   onSetArea = () => {

--- a/src/utils/__test_data__/sample-leaflet-layers.js
+++ b/src/utils/__test_data__/sample-leaflet-layers.js
@@ -1,0 +1,41 @@
+// contains objects standing in for Leaflet layers. 
+// only the toGeoJSON() function is available.
+
+export const polygon1 = [[
+        [-122.047786, 71.365177],
+        [-119.877348, 70.43932],
+        [-115.428989, 69.973676],
+        [-112.210557, 71.225339],
+        [-119.665702,72.198183],
+        [-122.047786,71.365177]
+    ]];
+    
+export const polygon2 = [[
+        [-127.819692, 67.709523],
+        [-126.720749, 66.35929],
+        [-123.509963, 66.216038],
+        [-119.828347, 67.061979],
+        [-120.280087, 68.558384],
+        [-125.128156, 68.667255],
+        [-127.819692, 67.709523],
+    ]];
+
+class fakeLeafletLayerWithGeoJSON {
+    constructor(polygon) {
+        this.geoJSON = {
+            "type": "Feature",
+            "properties": {},
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": polygon
+            }
+        };
+    }
+    
+    toGeoJSON() {
+        return this.geoJSON;
+    }
+}
+
+export const fakeLeafletLayer1 = new fakeLeafletLayerWithGeoJSON(polygon1);
+export const fakeLeafletLayer2 = new fakeLeafletLayerWithGeoJSON(polygon2);

--- a/src/utils/__tests__/test-geoJSON-leaflet.js
+++ b/src/utils/__tests__/test-geoJSON-leaflet.js
@@ -1,0 +1,105 @@
+import {geoJSONToLeafletLayers, 
+        layersToGeoJSON, 
+        layersToGeoJSONMultipolygon} from '../geoJSON-leaflet.js';
+import {fakeLeafletLayer1, 
+        fakeLeafletLayer2, 
+        polygon1, 
+        polygon2} from '../__test_data__/sample-leaflet-layers.js'
+
+describe('geoJSONToLeafletLayers', function() {});
+
+describe('layersToGeoJSON', function() {
+    const expectedSingle = {
+        "geometry": {
+            "coordinates": polygon1,
+            "type": "Polygon",
+        },
+        "properties": {
+            "source": "PCIC Climate Explorer"
+        },
+        "type": "Feature"
+    };
+    const expectedGeometry = {
+        "geometry": {
+            "geometries": [
+                {
+                    "coordinates": polygon1,
+                    "type": "Polygon"
+                },
+                {
+                    "coordinates": polygon2,
+                    "type": "Polygon"
+                }
+            ],
+            "type": "GeometryCollection"
+        },
+        "properties": { "source": "PCIC Climate Explorer"},
+        "type": "Feature"
+    };
+    
+    const expectedFeature = {
+        "features": [
+            {
+                "geometry": {
+                    "coordinates": polygon1,
+                    "type": "Polygon",
+                },
+                "properties": { "source": "PCIC Climate Explorer"},
+                "type": "Feature"
+            },
+            {
+                "geometry": {
+                    "coordinates": polygon2, 
+                    "type": "Polygon"
+                },
+                "properties": {},
+                "type": "Feature",
+            },
+        ],
+        "properties": {
+            "source": "PCIC Climate Explorer"
+        },
+        "type": "FeatureCollection"
+    };
+    
+    it('generates an empty collection from  0 layers', function () {
+        expect(layersToGeoJSON('FeatureCollection', [])).toEqual({});
+        expect(layersToGeoJSON('GeometryCollection', [])).toEqual({});
+    });
+    it('translates a single layer into a Feature', function () {
+        expect(layersToGeoJSON('FeatureCollection', [fakeLeafletLayer1])).toEqual(expectedSingle);
+        expect(layersToGeoJSON('GeometryCollection', [fakeLeafletLayer1])).toEqual(expectedSingle);
+
+    });
+    it('translates multiple layers into a GeometryCollection', function () {
+        expect(layersToGeoJSON('GeometryCollection', [fakeLeafletLayer1, fakeLeafletLayer2])).toEqual(expectedGeometry);
+    });
+    it('translates multiple layers into a FeatureCollection', function () {
+        expect(layersToGeoJSON('FeatureCollection', [fakeLeafletLayer1, fakeLeafletLayer2])).toEqual(expectedFeature);
+    });
+});
+
+describe('layersToGeoJSONMultipolygon', function() {
+    it('translates no layers', function() {
+        expect(layersToGeoJSONMultipolygon([])).toBeUndefined();
+    });
+    it('translates a single layer', function () {
+        const expected1 = {
+            "coordinates": [polygon1],
+            "type": "MultiPolygon",
+            "properties": {"source": "PCIC Climate Explorer"}
+        }
+        expect(layersToGeoJSONMultipolygon([fakeLeafletLayer1])).toEqual(expected1);
+    });
+    it('translates multiple layers', function () {
+        const expected2 = {
+            "coordinates": [polygon1, polygon2],
+            "type": "MultiPolygon",
+            "properties": {"source": "PCIC Climate Explorer"}
+            }
+
+        expect(layersToGeoJSONMultipolygon([fakeLeafletLayer1, fakeLeafletLayer2])).toEqual(expected2);
+    });
+});
+
+

--- a/src/utils/geoJSON-leaflet.js
+++ b/src/utils/geoJSON-leaflet.js
@@ -86,3 +86,24 @@ export function layersToGeoJSON(collectionType, layers) {
 
   throw new Error(`Invalid GeoJSON collection type: '${collectionType}'`);
 }
+
+// creates a geoJSON Multipolygon from selection geometry
+// the PCDS backend wants a WKT polygon, so even when the user draws only
+// a single selected polygon, the area should be a Multipolygon
+export function layersToGeoJSONMultipolygon(layers) {
+    if (layers.length === 0) {
+        return {};
+    }
+    else if (layers.length === 1) {
+        return  {
+            type: 'MultiPolygon',
+            coordinates: [layers[0].toGeoJSON().geometry.coordinates]
+        };
+    }
+    else {
+        return {
+            type: 'MultiPolygon',
+            coordinates: layers.map(layer => layer.toGeoJSON().geometry.coordinates)
+        };
+    }
+}

--- a/src/utils/geoJSON-leaflet.js
+++ b/src/utils/geoJSON-leaflet.js
@@ -98,12 +98,14 @@ export function layersToGeoJSONMultipolygon(layers) {
     else if (layers.length === 1) {
         return  {
             type: 'MultiPolygon',
+            properties: geoJSONProperties,
             coordinates: [layers[0].toGeoJSON().geometry.coordinates]
         };
     }
     else {
         return {
             type: 'MultiPolygon',
+            properties: geoJSONProperties,
             coordinates: layers.map(layer => layer.toGeoJSON().geometry.coordinates)
         };
     }

--- a/src/utils/geoJSON-leaflet.js
+++ b/src/utils/geoJSON-leaflet.js
@@ -95,18 +95,16 @@ export function layersToGeoJSONMultipolygon(layers) {
         // just cleared an existing selection.
         return undefined;
     }
-    else if (layers.length === 1) {
+    if (layers.length === 1) {
         return  {
             type: 'MultiPolygon',
             properties: geoJSONProperties,
             coordinates: [layers[0].toGeoJSON().geometry.coordinates]
         };
     }
-    else {
-        return {
-            type: 'MultiPolygon',
-            properties: geoJSONProperties,
-            coordinates: layers.map(layer => layer.toGeoJSON().geometry.coordinates)
+    return {
+        type: 'MultiPolygon',
+        properties: geoJSONProperties,
+        coordinates: layers.map(layer => layer.toGeoJSON().geometry.coordinates)
         };
-    }
 }

--- a/src/utils/geoJSON-leaflet.js
+++ b/src/utils/geoJSON-leaflet.js
@@ -92,7 +92,8 @@ export function layersToGeoJSON(collectionType, layers) {
 // a single selected polygon, the area should be a Multipolygon
 export function layersToGeoJSONMultipolygon(layers) {
     if (layers.length === 0) {
-        return {};
+        // just cleared an existing selection.
+        return undefined;
     }
     else if (layers.length === 1) {
         return  {

--- a/src/utils/portals-common/portals-common.js
+++ b/src/utils/portals-common/portals-common.js
@@ -11,7 +11,7 @@ import { isPointInPolygonWn } from '../geometry-algorithms';
 
 
 const checkGeoJSONPolygon = geometry => {
-  if (geometry['type'] !== 'Polygon') {
+  if (geometry['type'] !== 'MultiPolygon') {
     throw new Error(`Invalid geometry type: ${geometry['type']}`)
   }
 };
@@ -107,14 +107,13 @@ export const stationFilter = (
       if (!area) {
         return true;
       }
-      // TODO: Handle more generalized geometry?
-      //  See https://github.com/pacificclimate/station-data-portal/issues/21
-      checkGeoJSONPolygon(area.geometry);
-      // Dumbest possible version: Only test the first vertex list in the
-      // polygon.
-      return isPointInGeoJSONPolygon(
-        area.geometry.coordinates[0],
-        [station.histories[0].lon, station.histories[0].lat])
+      //area will always be a geoJSON MultiPolygon (even if there's only one polygon)
+      checkGeoJSONPolygon(area);
+
+      //return true if the station is in any selected polygon
+      return some(poly => isPointInGeoJSONPolygon(poly[0],
+            [station.histories[0].lon, station.histories[0].lat] ))(area.coordinates);
+
     }),
   )(allStations);
 };


### PR DESCRIPTION
This PR switches the internal representation of the area selected by a user from a geoJSON `Polygon` to a geoJSON `Multipolygon`. There are two reasons for this:

1. A user may want to select multiple polygons
2. Even if the user selects a single polygon, the PCDS backend expects a WKT `multipolygon`.

resolves #45 
resolves #21 

Currently, `master` merely prints out a URL to console instead of downloading data, so this branch hasn't been tested against a live server, but the console logs, such as this one:

```
### Download timeseries: pcds/agg/?from-date=2021%2F05%2F15&to-date=2021%2F05%2F17&network-name=&input-vars=&input-freq=&input-polygon=MULTIPOLYGON%20(((-122.172253%2070.857839%2C%20-117.036246%2071.594186%2C%20-113.496402%2070.894432%2C%20-116.570496%2069.624274%2C%20-122.172253%2070.857839)))&only-with-climatology=&download-timeseries=Timeseries&data-format=nc
```

seem to be [valid](http://docker-dev02.pcic.uvic.ca:30885/pcds/agg/?from-date=2021%2F05%2F15&to-date=2021%2F05%2F17&network-name=&input-vars=&input-freq=&input-polygon=MULTIPOLYGON%20(((-122.172253%2070.857839%2C%20-117.036246%2071.594186%2C%20-113.496402%2070.894432%2C%20-116.570496%2069.624274%2C%20-122.172253%2070.857839)))&only-with-climatology=&download-timeseries=Timeseries&data-format=nc).