### PR TITLE
Fix base layer update lag when zooming

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -22,6 +22,6 @@ jobs:
       # https://github.com/facebook/create-react-app/issues/3657
       run: |
         npm --version
-        npm install
+        npm install --force
         CI=false npm run build
         npm test

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,6 +21,7 @@ RUN chown node /app
 
 ENV PATH /app/node_modules/.bin:$PATH
 COPY --chown=node:node  package.json /app/package.json
+COPY --chown=node:node  package-lock.json /app/package-lock.json
 
 RUN npm install --quiet
 RUN npm install -g serve

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,9 +21,8 @@ RUN chown node /app
 
 ENV PATH /app/node_modules/.bin:$PATH
 COPY --chown=node:node  package.json /app/package.json
-COPY --chown=node:node  package-lock.json /app/package-lock.json
 
-RUN npm install --quiet
+RUN npm install --quiet --force
 RUN npm install -g serve
 COPY --chown=node:node . /app
 

--- a/src/components/main/Body/Body.js
+++ b/src/components/main/Body/Body.js
@@ -3,7 +3,7 @@ import { useBooleanStateWithToggler } from '../../../hooks';
 import {
   Button,
   Checkbox,
-  Col,
+  Col, ControlLabel, FormControl,
   FormGroup,
   Panel,
   Row,
@@ -43,7 +43,7 @@ import StationFilters, { useStationFiltering }
 import JSONstringify from '../../util/JSONstringify';
 import baseMaps from '../../maps/baseMaps';
 import {
-  markerClusteringAvailable,
+  markerClusteringAvailable, showDevTab,
   showReloadStationsButton,
   stationDebugFetchOptions,
 } from '../../../utils/configuration';
@@ -186,6 +186,10 @@ function Body() {
     [area, filteredStations]
   );
 
+  ///// Dev tools state, callbacks, etc. go here. They come and go.
+  const [updateDelay, setUpdateDelay] = useState(500);
+  /////
+
   return (
     <div className={css.portal}>
       <Row>
@@ -199,6 +203,13 @@ function Body() {
               allNetworks={allNetworks}
               allVariables={allVariables}
               onSetArea={setArea}
+              markerOptions={{
+                // radius set by station markers component
+                weight: 1,
+                fillOpacity: 0.75,
+                color: '#000000',
+                updateDelay,
+              }}
               markerClusterOptions={uzeMarkercluster && markerClusterOptions}
             />,
 
@@ -211,9 +222,23 @@ function Body() {
                 )}
                 <Tabs
                   id="non-map-controls"
-                  defaultActiveKey={'Filters'}
+                  defaultActiveKey={showDevTab ? 'Dev' : 'Filters'}
                   className={css.mainTabs}
                 >
+                  { showDevTab && (
+                    <Tab eventKey={'Dev'} title={'Dev'}>
+                      <ControlLabel>Marker update delay (ms)</ControlLabel>
+                      <FormGroup>
+                        <FormControl
+                          componentClass={"input"}
+                          placeholder={"Zoom level"}
+                          type={"number"}
+                          value={updateDelay}
+                          onChange={e => setUpdateDelay(e.target.value)}
+                        />
+                      </FormGroup>
+                    </Tab>
+                  )}
                   { markerClusteringAvailable && (
                     <Tab
                       eventKey={'Clustering'}

--- a/src/components/maps/StationMap/StationMap.js
+++ b/src/components/maps/StationMap/StationMap.js
@@ -131,11 +131,7 @@ function StationMap({
       preferCanvas={true}
       maxZoom={13}
     >
-      {/*<ReportZoom callback={zoomCallback}/>*/}
-      <MapInfoDisplay
-        position={"bottomleft"}
-        what={map => `Zoom: ${map.getZoom()}`}
-      />
+      <MapInfoDisplay position={"bottomleft"}/>
       <FeatureGroup ref={userShapeLayerRef}>
         <EditControl
           position={'topleft'}

--- a/src/components/maps/StationMap/StationMap.js
+++ b/src/components/maps/StationMap/StationMap.js
@@ -38,15 +38,15 @@
 
 
 import PropTypes from 'prop-types';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 
-import { FeatureGroup, LayerGroup, useMap, useMapEvents } from 'react-leaflet';
+import { FeatureGroup, LayerGroup } from 'react-leaflet';
 import { EditControl } from 'react-leaflet-draw';
 import MarkerCluster from '../MarkerCluster';
 import L from 'leaflet';
 
 import MapInfoDisplay from '../MapInfoDisplay';
-import { ManyStationMarkers, zoomToMarkerRadius } from '../StationMarkers';
+import { ManyStationMarkers } from '../StationMarkers';
 import { layersToGeoJSONMultipolygon } from '../../../utils/geoJSON-leaflet';
 
 import logger from '../../../logger';
@@ -58,17 +58,6 @@ logger.configure({ active: true });
 const smtimer = getTimer("StationMarker timing")
 smtimer.log();
 
-function ReportZoom({ callback }) {
-  const eventCallback = (e) => {
-    console.log("### ReportZoom event", e)
-    callback(leafletMap.getZoom());
-  };
-  const leafletMap = useMapEvents({
-    load: eventCallback,
-    zoomend: eventCallback,
-  });
-  return null;
-}
 
 function StationMap({
   BaseMap,
@@ -78,10 +67,11 @@ function StationMap({
   allVariables,
   onSetArea = () => {},
   markerOptions = {
-    radius: 4,
+    // radius set by station markers component
     weight: 1,
     fillOpacity: 0.75,
     color: '#000000',
+    updateDelay: 500,  // This is our extension; Leaflet ignores
   },
   markerClusterOptions,
   userShapeStyle = {
@@ -90,20 +80,6 @@ function StationMap({
   },
 }) {
   const userShapeLayerRef = useRef();
-  const [markerRadius, setMarkerRadius] = useState();
-  const zoomCallback = zoom => {
-    setMarkerRadius(zoomToMarkerRadius(zoom));
-  };
-
-  // Control marker radius as a function of zoom level.
-  // const leafletMap = useMap();
-  // const [markerRadius, setMarkerRadius] =
-  //   useState(zoomToMarkerRadius(leafletMap.getZoom()));
-  // useMapEvents({
-  //   zoomend: () => {
-  //     setMarkerRadius(zoomToMarkerRadius(leafletMap.getZoom()));
-  //   }
-  // });
 
   // TODO: Remove
   // const [geometryLayers, setGeometryLayers] = useState([]);
@@ -132,8 +108,6 @@ function StationMap({
 
   smtimer.log();
   smtimer.resetAll();
-
-  // alert("StationMap render")
 
   const markers = (
     <ManyStationMarkers

--- a/src/components/maps/StationMarkers/StationMarkers.js
+++ b/src/components/maps/StationMarkers/StationMarkers.js
@@ -189,7 +189,7 @@ OneStationMarkers.propTypes = {
 // Convert a zoom level to a marker radius according to zoomToMarkerRadiusSpec,
 // which is an array of pairs of [zoom, radius] values, in ascending order of
 // zoom. This value is set from an env var. See utils/configuration for details.
-function zoomToMarkerRadius(zoom) {
+export function zoomToMarkerRadius(zoom) {
   for (const [_zoom, radius] of zoomToMarkerRadiusSpec) {
     if (zoom <= _zoom) {
       return radius;
@@ -200,7 +200,7 @@ function zoomToMarkerRadius(zoom) {
 
 
 function ManyStationMarkers({
-  stations, allNetworks, allVariables
+  stations, allNetworks, allVariables, markerOptions
 }) {
   // Control marker radius as a function of zoom level.
   const leafletMap = useMap();
@@ -208,15 +208,18 @@ function ManyStationMarkers({
     useState(zoomToMarkerRadius(leafletMap.getZoom()));
   useMapEvents({
     zoomend: () => {
-      setMarkerRadius(zoomToMarkerRadius(leafletMap.getZoom()));
+      setTimeout(
+        () => {
+          setMarkerRadius(zoomToMarkerRadius(leafletMap.getZoom()))
+        },
+        1000
+      );
     }
   });
 
-  const markerOptions = {
+  const adjustedMarkerOptions = {
+    ...markerOptions,
     radius: markerRadius,
-    weight: 1,
-    fillOpacity: 0.75,
-    color: '#000000',
   };
   return map(
     station => (
@@ -225,7 +228,7 @@ function ManyStationMarkers({
         station={station}
         allNetworks={allNetworks}
         allVariables={allVariables}
-        markerOptions={markerOptions}
+        markerOptions={adjustedMarkerOptions}
       />
     ),
     stations

--- a/src/utils/configuration.js
+++ b/src/utils/configuration.js
@@ -21,6 +21,8 @@ export const markerClusteringAvailable =
 export const showReloadStationsButton =
   configBool("SHOW_RELOAD_STATIONS_BUTTON");
 
+export const showDevTab = configBool("SHOW_DEV_TAB");
+
 let zoomToMarkerRadiusSpec = [
   [7, 10], [99, 4],
 ];


### PR DESCRIPTION
Resolves #125

This PR decouples the update of the marker radii from the update of the base map (and the current markers) at the new zoom level by introducing a sufficiently long delay between the `zoomend` event and an update to the marker radius. 

When there is insufficient delay (or none), React re-renders the markers (with different radius) before updating the basemap. This produces an unpleasant visual effect (the basemap looks bad for about 1 - 2 s). Note that this effect only occurs when the zoom crosses a boundary where the marker radius changes (currently, this is boundary is between zoom 7 and 8). It is most noticeable when zooming out.

With sufficient delay, re-rendering of the markers is done separately, and the basemap updates immediately. The re-rendering of the markers (with different radius) is visibly delayed, a combination of the delay in setting the new radius and the (1 - 2 s) time required to re-render the markers at the new radius. This is much less unpleasant to my eye.

On my dev laptop, "sufficiently long" seems to be >= 300 ms. It may be different for other platforms, so this will be worth checking.

Demo: http://docker-dev02.pcic.uvic.ca:30511/