### PR TITLE
Improve use of concurrency

### DIFF
--- a/src/components/controls/StationFilters/StationFilters.js
+++ b/src/components/controls/StationFilters/StationFilters.js
@@ -21,10 +21,11 @@
 // complexity, and it places the state declarations right next to a key
 // consumer of them, the component `StationFilters`.
 
-import React, { useState, useTransition } from 'react';
+import React from 'react';
 
 import './StationFilters.css';
 import { Col, Row } from 'react-bootstrap';
+
 import NetworkSelector from '../../selectors/NetworkSelector';
 import VariableSelector from '../../selectors/VariableSelector';
 import FrequencySelector
@@ -33,89 +34,31 @@ import DateSelector from '../../selectors/DateSelector';
 import OnlyWithClimatologyControl
   from '../../controls/OnlyWithClimatologyControl';
 import { commonSelectorStyles } from '../../selectors/styles';
+import { usePairedImmerByKey } from '../../../hooks';
 
 export const useStationFiltering = () => {
-  const [startDate, setStartDate] = useState(null);
-  const [endDate, setEndDate] = useState(null);
-  const [selectedNetworksOptions, setSelectedNetworksOptions] = useState([]);
-  const [networkActions, setNetworkActions] = useState(null);
-  const [selectedVariablesOptions, setSelectedVariablesOptions] = useState([]);
-  const [variableActions, setVariableActions] = useState(null);
-  const [selectedFrequenciesOptions, setSelectedFrequenciesOptions] = useState([]);
-  const [frequencyActions, setFrequencyActions] = useState(null);
-  const [onlyWithClimatology, setOnlyWithClimatology] = useState(false);
-  const toggleOnlyWithClimatology = () =>
-    setOnlyWithClimatology(!onlyWithClimatology);
-  // TODO: Remove? Not presently used, but there is commented out code
-  //  in StationFilters that uses these.
-  // const handleClickAll = () => {
-  //   networkActions.selectAll();
-  //   variableActions.selectAll();
-  //   frequencyActions.selectAll();
-  // };
-  // const handleClickNone = () => {
-  //   networkActions.selectNone();
-  //   variableActions.selectNone();
-  //   frequencyActions.selectNone();
-  // };
-
-  // Define a transition such that updates to the filtering parameters are
-  // marked as lower priority.
-  const [isPending, startTransition] = useTransition();
-
-  // This function wraps a setter in a transition. Evidently it is OK to wrap
-  // different, independently-called setters in the same transition.
-  const handleAsTransition = setter => value => {
-    startTransition(() => setter(value));
-  };
-
-  return {
-    startDate,
-    setStartDate: handleAsTransition(setStartDate),
-    endDate,
-    setEndDate: handleAsTransition(setEndDate),
-    selectedNetworksOptions,
-    setSelectedNetworksOptions: handleAsTransition(setSelectedNetworksOptions),
-    networkActions,
-    setNetworkActions,
-    selectedVariablesOptions,
-    setSelectedVariablesOptions:
-      handleAsTransition(setSelectedVariablesOptions),
-    variableActions,
-    setVariableActions,
-    selectedFrequenciesOptions,
-    setSelectedFrequenciesOptions:
-      handleAsTransition(setSelectedFrequenciesOptions),
-    frequencyActions,
-    setFrequencyActions,
-    onlyWithClimatology,
-    toggleOnlyWithClimatology: handleAsTransition(toggleOnlyWithClimatology),
-    isPending,
-  };
+  const { normal, transitional, isPending, setState } = usePairedImmerByKey({
+    startDate: null,
+    endDate: null,
+    selectedNetworksOptions: [],
+    networkActions: null,
+    selectedVariablesOptions: [],
+    variableActions: null,
+    selectedFrequenciesOptions: [],
+    frequencyActions: null,
+    onlyWithClimatology: false,
+  });
+  setState.toggleOnlyWithClimatology = () =>
+    setState.onlyWithClimatology(!normal.onlyWithClimatology);
+  return { normal, transitional, isPending, setState };
 };
 
 function StationFilters({
-  startDate,
-  setStartDate,
-  endDate,
-  setEndDate,
+  state,
+  setState,
   allNetworks,
-  selectedNetworksOptions,
-  setSelectedNetworksOptions,
-  networkActions,
-  setNetworkActions,
   allVariables,
-  selectedVariablesOptions,
-  setSelectedVariablesOptions,
-  variableActions,
-  setVariableActions,
   allFrequencies,
-  selectedFrequenciesOptions,
-  setSelectedFrequenciesOptions,
-  frequencyActions,
-  setFrequencyActions,
-  onlyWithClimatology,
-  toggleOnlyWithClimatology,
   rowClasses = { className: "mb-3" },
 }) {
   return (
@@ -125,15 +68,15 @@ function StationFilters({
           {/*<Button size={'sm'} onClick={handleClickAll}>Select all criteria</Button>*/}
           {/*<Button size={'sm'} onClick={handleClickNone}>Clear all criteria</Button>*/}
           <DateSelector
-            value={startDate}
-            onChange={setStartDate}
+            value={state.startDate}
+            onChange={setState.startDate}
             label={'Start Date'}
           />
         </Col>
         <Col lg={6} md={6} sm={6}>
           <DateSelector
-            value={endDate}
-            onChange={setEndDate}
+            value={state.endDate}
+            onChange={setState.endDate}
             label={'End Date'}
           />
         </Col>
@@ -141,8 +84,8 @@ function StationFilters({
       <Row {...rowClasses}>
         <Col lg={12} md={12} sm={12}>
           <OnlyWithClimatologyControl
-            value={onlyWithClimatology}
-            onChange={toggleOnlyWithClimatology}
+            value={state.onlyWithClimatology}
+            onChange={setState.toggleOnlyWithClimatology}
           />
         </Col>
       </Row>
@@ -150,9 +93,9 @@ function StationFilters({
         <Col lg={12} md={12} sm={12}>
           <NetworkSelector
             allNetworks={allNetworks}
-            onReady={setNetworkActions}
-            value={selectedNetworksOptions}
-            onChange={setSelectedNetworksOptions}
+            onReady={setState.networkActions}
+            value={state.selectedNetworksOptions}
+            onChange={setState.selectedNetworksOptions}
             isSearchable
             isClearable={false}
             styles={commonSelectorStyles}
@@ -164,9 +107,9 @@ function StationFilters({
         <Col lg={12} md={12} sm={12}>
           <VariableSelector
             allVariables={allVariables}
-            onReady={setVariableActions}
-            value={selectedVariablesOptions}
-            onChange={setSelectedVariablesOptions}
+            onReady={setState.variableActions}
+            value={state.selectedVariablesOptions}
+            onChange={setState.selectedVariablesOptions}
             isSearchable
             isClearable={false}
             styles={commonSelectorStyles}
@@ -178,9 +121,9 @@ function StationFilters({
         <Col lg={12} md={12} sm={12}>
           <FrequencySelector
             allFrequencies={allFrequencies}
-            onReady={setFrequencyActions}
-            value={selectedFrequenciesOptions}
-            onChange={setSelectedFrequenciesOptions}
+            onReady={setState.frequencyActions}
+            value={state.selectedFrequenciesOptions}
+            onChange={setState.selectedFrequenciesOptions}
             isClearable={false}
             styles={commonSelectorStyles}
           />

--- a/src/components/maps/StationMap/StationMap.js
+++ b/src/components/maps/StationMap/StationMap.js
@@ -39,7 +39,6 @@
 
 import PropTypes from 'prop-types';
 import React, {
-  useDeferredValue,
   useEffect,
   useMemo,
   useRef,
@@ -85,11 +84,6 @@ function StationMap({
   // should be true if and only if slow updates to the map are pending
   // due to an external update.
 }) {
-  // TODO: It's possible that raising this deferral up to Body, so that
-  //  filtering is deferred, would make an even greater improvement in UI
-  //  responsiveness.
-  const deferredStations = useDeferredValue(stations);
-
   const userShapeLayerRef = useRef();
 
   // TODO: Remove
@@ -139,21 +133,19 @@ function StationMap({
   smtimer.log();
   smtimer.resetAll();
 
-  // Make the markers dependent on `deferredStations`, so that updating them
-  // is lower priority than other updates (e.g., the filter controls).
-  //
-  // Splitting the `deferredStations` memoization into two steps, markers and
+  // Splitting the `stations` memoization into two steps, markers and
   // layer group, seems to provide a more responsive UI. It's not clear why.
+  // Or I might just be seeing ghosts.
 
   const markers = useMemo(() =>
     <ManyStationMarkers
-      stations={deferredStations}
+      stations={stations}
       allNetworks={allNetworks}
       allVariables={allVariables}
       markerOptions={markerOptions}
       mapEvents={markerMapEvents}
     />,
-    [deferredStations, markerOptions]
+    [stations, markerOptions]
   );
 
   const markerLayerGroup = useMemo(() =>

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -1,9 +1,12 @@
-import { useState } from 'react';
+import { useState, useTransition } from 'react';
+import { useImmer } from 'use-immer';
+
 
 export const useStateWithEventHandler = init => {
   const [state, setState] = useState(init);
   return [state, e => setState(e.target.value)]
 };
+
 
 export const useBooleanStateWithToggler = init => {
   const [state, setState] = useState(init);
@@ -11,3 +14,60 @@ export const useBooleanStateWithToggler = init => {
 };
 
 
+// This hook provides a pair of immutable (immer) states, `normal` and
+// `transitional`, that are updated together by a single setter. The normal
+// state is updated normally -- that is directly, urgently. The transitional
+// state is updated inside a transition -- that is, at lower priority.
+// The hook returns 4 named items:
+//
+//    { normal, transitional, isPending, setState }
+//
+// where `normal` and `transitional` are the states, `isPending` is the
+// pending state from the transition, and `setState` updates both states as
+// described above.
+export const usePairedImmer = (initial) => {
+  const [normal, setNormal] = useImmer(initial);
+  const [transitional, setTransitional] = useImmer(initial);
+  const [isPending, startTransition] = useTransition();
+  const setState = update => {
+    setNormal(update);
+    startTransition(() => {
+      setTransitional(update);
+    });
+  }
+  return { normal, transitional, isPending, setState };
+};
+
+
+// This hook provides paired immer states as in `usePairedImmer`, with some
+// added conveniences. The initial state is expected to be hash object. The
+// returned `setState` is extended with convenience value setters for each
+// top-level key of the initial object. Note: The convenience setters take a
+// plain value, not an immer update function as `setState` does.
+//
+// This arrangement makes it easy to treat a single immutable state as a group
+// of named (by key) paired states, each with its own easy-to-use value setter.
+//
+// For example:
+//
+//    const { normal, transitional, isPending, setState } =
+//      usedPairedImmerByKey({ a: 1, b: 2 });
+//
+// The function `setState`, in addition to being an immer setter as in
+// `usePairedImmer`, also has the following convenience state-setting functions
+// attached to it:
+//
+//    setState.a(value)   // updates `normal.a`, `transitional.a` with `value`
+//    setState.b(value)   // updates `normal.b`, `transitional.b` with `value`
+export const usePairedImmerByKey = (initial) => {
+  const pairedImmer = usePairedImmer(initial);
+  const { normal, setState } = pairedImmer;
+  for (const key of Object.keys(normal)) {
+    setState[key] = value => {
+      setState(draft => {
+        draft[key] = value;
+      });
+    };
+  }
+  return pairedImmer;
+};

--- a/src/hooks2.test.js
+++ b/src/hooks2.test.js
@@ -1,0 +1,66 @@
+import { renderHook, act } from '@testing-library/react';
+import { usePairedImmer, usePairedImmerByKey } from "./hooks";
+
+
+describe("usePairedImmer", () => {
+  const initial = { a: 1, b: 2 };
+
+  it("renders initial state in both state objects", () => {
+    const { result } = renderHook(() => usePairedImmer(initial));
+    for (const key of Object.keys(initial)) {
+      expect(result.current.normal[key]).toBe(initial[key]);
+      expect(result.current.transitional[key]).toBe(initial[key]);
+    }
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it("updates both state objects", () => {
+    const { result } = renderHook(() => usePairedImmer(initial));
+    expect(result.current.normal.a).toBe(initial.a);
+    act(() => {
+      result.current.setState(draft => {
+        draft.a = 99;
+      })
+    });
+    expect(result.current.normal.a).toBe(99);
+    expect(result.current.transitional.a).toBe(99);
+  });
+
+  // it("contains expected convenience setters", () => {
+  //   const [normal, transitional, isPending, setState] = result.current;
+  //   for (const key of Object.keys(initial)) {
+  //     expect(setState[key]).toBeDefined;
+  //   }
+  // });
+});
+
+describe("usePairedImmerByKey", () => {
+  const initial = { a: 1, b: 2 };
+
+  it("renders initial state in both state objects", () => {
+    const { result } = renderHook(() => usePairedImmerByKey(initial));
+    for (const key of Object.keys(initial)) {
+      expect(result.current.normal[key]).toBe(initial[key]);
+      expect(result.current.transitional[key]).toBe(initial[key]);
+    }
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it("adds the convenience setters, and they work", () => {
+    const { result } = renderHook(() => usePairedImmerByKey(initial));
+    for (const key of Object.keys(initial)) {
+      expect(result.current.setState[key]).toBeDefined();
+    }
+
+    expect(result.current.normal.a).toBe(initial.a);
+    act(() => {
+      result.current.setState.a(99)
+    });
+    expect(result.current.normal.a).toBe(99);
+    expect(result.current.transitional.a).toBe(99);
+  });
+
+
+});
+
+

--- a/src/utils/station-filtering/station-filtering.js
+++ b/src/utils/station-filtering/station-filtering.js
@@ -163,20 +163,26 @@ export const stationInsideMultiPolygon = ft.timeThis("stationInsideMultiPolygon"
 });
 
 
-export const stationFilter = (
-  startDate, endDate, selectedNetworks, selectedVariables, selectedFrequencies,
-  onlyWithClimatology, allNetworks, allVariables, allStations
-) => {
+export const stationFilter = ({
+  startDate,
+  endDate,
+  selectedNetworksOptions,
+  selectedVariablesOptions,
+  selectedFrequenciesOptions,
+  onlyWithClimatology,
+  allVariables,
+  allStations,
+}) => {
   ft.resetAll();
   const selectedVariableIds = ft.timeThis("selectedVariableIds")(flow(
     map(selectedVariable => selectedVariable.contexts),
     flatten,
     map(context => context.id),
     uniq,
-  ))(selectedVariables);
+  ))(selectedVariablesOptions);
 
   const selectedFrequencyValues =
-    map(option => option.value)(selectedFrequencies);
+    map(option => option.value)(selectedFrequenciesOptions);
 
   const climatologyVariableIds = ft.timeThis("climatologyVariableIds")(
     flow(
@@ -187,7 +193,7 @@ export const stationFilter = (
 
   const r = filter(station => (
         stationMatchesDates(station, startDate, endDate, false)
-        && stationInAnyNetwork(station, selectedNetworks)
+        && stationInAnyNetwork(station, selectedNetworksOptions)
         && stationReportsSomeVariables(station, selectedVariableIds)
         && stationReportsAnyFreqs(station, selectedFrequencyValues)
         && (


### PR DESCRIPTION
My understanding of concurrency is much better after a few days of working and thinking about it. This PR changes how concurrency is applied to the marker updates. It simplifies the code and results in considerably improved UI behaviour, including actually making the non-map UI interactive while the markers are updated (in a transition). This was a claim in an earlier PR but it was false.